### PR TITLE
change sleep function to avoid lockup in IRQs

### DIFF
--- a/tf_card.c
+++ b/tf_card.c
@@ -433,7 +433,7 @@ DSTATUS disk_initialize (
 
     if (drv) return STA_NOINIT;         /* Supports only drive 0 */
     pico_fatfs_init_spi();              /* Initialize SPI */
-    sleep_ms(10);
+    busy_wait_us(10 * 1000ull);
 
     if (Stat & STA_NODISK) return Stat; /* Is card existing in the soket? */
 


### PR DESCRIPTION
when writing a GPIO IRQ to make the SD card remount when an SD card is inserted, i came across this issue

sleep_ms causes hangs in IRQs: https://github.com/raspberrypi/pico-sdk/issues/108